### PR TITLE
[OWL-195] fix screen datetimepicker bug

### DIFF
--- a/rrd/templates/base_ng.html
+++ b/rrd/templates/base_ng.html
@@ -36,8 +36,6 @@
         <script src="{{url_for('static', filename='bootstrap-tokenfield/bootstrap-tokenfield.min.js')}}"></script>
         <link rel="stylesheet" href="{{url_for('static', filename='grafana_statics/grafana.light.min.92672c38.css')}}">
         <link rel="icon" type="image/png" href="{{url_for('static', filename='grafana_statics/fav32.png')}}">
-        <script type="text/javascript" src="{{url_for('static', filename='grafana_statics/jquery-2.1.4.min.js')}}" />
-        <script src="{{url_for('static', filename='grafana_statics/app.6903da0e.js')}}"></script>
 
     {% endblock %}
 


### PR DESCRIPTION
### What? Why?

發現問題點
commit 32d77955d6de7f690ffbc0438dff9c20f6865d98
原因 grafana app.6903da0e.js 與 angular-bootstrap-datetimepicker 套件有衝突
將不載入 jquery 2.1.4 & app.6903da0e.js 兩隻 javascript ，經測試沒有發現有問題，app.6903da0e.js 沒有side menu 邏輯，主要為 grafana 主邏輯
- no include jquery.2.1.4
- no include grafana app.6903da0e.js
### How was it tested?

localhost

cc @hitripod 
