### PR TITLE
[OWL-298] fix counter search list

### DIFF
--- a/rrd/static/css/base.css
+++ b/rrd/static/css/base.css
@@ -261,3 +261,9 @@ a.tab_current:hover {
     color:#ACABAB;
     font-size:11px;
 }
+
+/* index */
+.DBCSS-table-counter-name {
+    word-break: break-all;
+}
+

--- a/rrd/static/js/xperf.js
+++ b/rrd/static/js/xperf.js
@@ -66,7 +66,7 @@ function fn_list_counters(){
                     }
                     var line_html = '<tr>'
                     + '<td><input type="checkbox" data-fullkey="'+c[0]+'"></input></td>'
-                    + '<td><a href="javascript:void(0);" onclick="fn_show_chart(\'' + c[0] + '\')" >' + c[0] + '</a></td>'
+                    + '<td><a class ="DBCSS-table-counter-name" href="javascript:void(0);" onclick="fn_show_chart(\'' + c[0] + '\')" >' + c[0] + '</a></td>'
                     + '<td>'+ display_counter_type +'</td>'
                     + '<td>'+ c[2] +'s</td>'
                     + '</tr>'


### PR DESCRIPTION
### What? Why?

目前 Dashboard 搜尋 Endpoints & Counters 結果列表是由 HTML table 呈現，counter 名稱的 欄位跑版是因為有 counter 名稱過長。

與 JJ & 迷你馬 討論當瀏覽視窗寬度較小時應呈現完整資訊，將過長資訊斷行呈現，而不採取遮蔽過長訊息內容
### How was it tested?

localhost

cc @hitripod 
