### PR TITLE
[OWL-274] Support the features of nqm

### DIFF
--- a/rrd/model/endpoint_counter.py
+++ b/rrd/model/endpoint_counter.py
@@ -82,16 +82,10 @@ class EndpointCounter(object):
         if isPacketLossRate:
             rows = list(rows)
             newLists = list()
-            #for row in rows:
-            #    newList = list(row)
-            #    newList[2] = 'packet-loss-rate'
-            #    newList = tuple(newList)
-            #    newLists.append(newList)
             newList = list(rows[0]) # 隨便找一個
             newList[2] = 'packet-loss-rate'
             newList = tuple(newList)
             newLists.append(newList)
-
             rows = rows + newLists
             rows = tuple(rows)
         elif isAverage:
@@ -101,7 +95,6 @@ class EndpointCounter(object):
             newList[2] = 'average'
             newList = tuple(newList)
             newLists.append(newList)
-
             rows = rows + newLists
             rows = tuple(rows)
         return [cls(*row) for row in rows]

--- a/rrd/model/endpoint_counter.py
+++ b/rrd/model/endpoint_counter.py
@@ -53,13 +53,13 @@ class EndpointCounter(object):
                 sql += ''' and counter like %s'''
 
         if 'isp' in tags:
-            sql += tag_query(tags, args, 'isp'):
+            sql += tag_query(tags, args, 'isp')
         if 'province' in tags:
-            sql += tag_query(tags, args, 'isp'):
+            sql += tag_query(tags, args, 'isp')
         if 'city' in tags:
-            sql += tag_query(tags, args, 'isp'):
+            sql += tag_query(tags, args, 'isp')
         if 'tag' in tags:
-            sql += tag_query(tags, args, 'isp'):
+            sql += tag_query(tags, args, 'isp')
 
         args += [start, limit]
         sql += ''' limit %s,%s'''


### PR DESCRIPTION
First, it supports tag searching with **or** logic. If you want to search metrics with this logic: `key=val1` **or** `key=val2`, just type `key=val1,val2`. Second, It supports the queries of the keywords: `average`, `packet-loss-rate`. If you type `average`, it comes out a set of counters of of `transmission-time` with an additional counter `average`. If you type `packet-loss-rate`, it comes out a set of counters of of `packets-sent` with an additional counter `packet-loss-rate`. In both cases, select all the counters and check it out!
