### PR TITLE
[OWL-304] fix graph id is empty

### DIFF
--- a/rrd/model/graph.py
+++ b/rrd/model/graph.py
@@ -154,6 +154,9 @@ class TmpGraph(object):
         cursor = db_conn.execute('''insert ignore into tmp_graph (endpoints, counters, ck) values(%s, %s, %s) ON DUPLICATE KEY UPDATE time_=%s''',
                 (es, cs, ck, datetime.datetime.now()))
         id_ = cursor.lastrowid
+        if not id_:
+            cursor = db_conn.execute("select id from tmp_graph where ck='" + ck + "'")
+            id_ = cursor.fetchone()[0]
         db_conn.commit()
         cursor and cursor.close()
         return id_


### PR DESCRIPTION
### What? Why?

dashboard 搜尋頁選擇看圖時呼叫的 API `/charts` 與 看圖頁面使用的 API `/chart` 後端 python 不管 新增或是搜尋都是使用 `rrd.model.graph` 裡的 `add` 方法

導致 graph id 為空陣列，前端沒有取得 API 必要參數
### How was it tested?

localhost

cc @hitripod 
