### PR TITLE
[OWL-342] add db cursor health check inside api/health

### DIFF
--- a/rrd/view/api.py
+++ b/rrd/view/api.py
@@ -2,7 +2,7 @@
 import json
 from flask import request, abort, g
 from rrd import app
-
+from rrd.store import dashboard_db_conn as db_con
 from rrd.model.endpoint import Endpoint
 from rrd.model.endpoint_counter import EndpointCounter
 from rrd.model.graph import TmpGraph
@@ -14,6 +14,7 @@ from rrd.model.tag_endpoint import TagEndpoint
 
 @app.route("/api/health")
 def health_check():
+    db_con._conn.cursor()
     resp = {
         "status": "ok",
         "msg": "system work well"


### PR DESCRIPTION
測試後發現,flask並不會在routing時 主動trigger exception.
會導致系統永遠都是 status: "ok" , 即使db已經無法連線.
所以加上db cursor get 機制在health api裡, 如果db連線以錯誤時可以正確報錯

```
{"status": "failed", "msg": "dashboard got problem now, please contact system administrator"}
```
